### PR TITLE
Fixed PutBlockList

### DIFF
--- a/BlobSync/AzureOps.cs
+++ b/BlobSync/AzureOps.cs
@@ -245,8 +245,7 @@ namespace BlobSync
             var client = AzureHelper.GetCloudBlobClient();
             var container = client.GetContainerReference(containerName);
             var blob = container.GetBlockBlobReference(blobName);
-            var blobIdList = blob.DownloadBlockList(BlockListingFilter.Committed);
-            var overlap = (from b in blobIdList where blockIdArray.Contains(b.Name) select b).ToList();
+            
             blob.PutBlockList(blockIdArray);
         }
 


### PR DESCRIPTION
PutBlockList method generates exception when blob.DownloadBlockList is called from UploadFile method, When Blob and signature does not exist. Removed unused overlap.
